### PR TITLE
Release Mastodon Chart 4.1.0

### DIFF
--- a/charts/mastodon/CHANGELOG.md
+++ b/charts/mastodon/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2022-12-03
 ### Added
 - Add support for disabling `PREPARED_STATEMENTS` when connecting to the database (https://github.com/mastodon/chart/pull/5)
 - Add support for setting `ALTERNATE_DOMAINS` (https://github.com/mastodon/chart/pull/2)

--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
### Added
- Add support for disabling `PREPARED_STATEMENTS` when connecting to the database (https://github.com/mastodon/chart/pull/5)
- Add support for setting `ALTERNATE_DOMAINS` (https://github.com/mastodon/chart/pull/2)
- Fix LDAP (https://github.com/mastodon/chart/pull/3)